### PR TITLE
Enhancement: Add `str` type hint and validator for `email` field

### DIFF
--- a/pydantic_openapi_schema/v3_0_3/contact.py
+++ b/pydantic_openapi_schema/v3_0_3/contact.py
@@ -1,6 +1,6 @@
-from typing import Optional
+from typing import Optional, Union
 
-from pydantic import AnyUrl, BaseModel, EmailStr, Extra
+from pydantic import AnyUrl, BaseModel, EmailStr, Extra, validator
 
 
 class Contact(BaseModel):
@@ -18,10 +18,29 @@ class Contact(BaseModel):
     The URL pointing to the contact information. MUST be in the format of a URL.
     """
 
-    email: Optional[EmailStr] = None
+    email: Optional[Union[EmailStr,str]] = None
     """
     The email address of the contact person/organization. MUST be in the format of an email address.
     """
+    @validator("email", pre=True)
+    def validate_email(  # pylint: disable=no-self-argument
+        cls, v: Union[EmailStr, str],
+    ) -> EmailStr:
+        """Validates that email is a valid email address
+
+        Args:
+            v (EmailStr|str): Holds the email string to be validated
+
+        Raises:
+            ValueError: Value is not a valid email address
+
+        Returns:
+            _type_: CompressionBackend
+        """
+        if isinstance(v, str):
+            v = EmailStr(v)
+        return v
+
 
     class Config:
         extra = Extra.ignore

--- a/pydantic_openapi_schema/v3_0_3/contact.py
+++ b/pydantic_openapi_schema/v3_0_3/contact.py
@@ -18,13 +18,15 @@ class Contact(BaseModel):
     The URL pointing to the contact information. MUST be in the format of a URL.
     """
 
-    email: Optional[Union[EmailStr,str]] = None
+    email: Optional[Union[EmailStr, str]] = None
     """
     The email address of the contact person/organization. MUST be in the format of an email address.
     """
+
     @validator("email", pre=True)
     def validate_email(  # pylint: disable=no-self-argument
-        cls, v: Union[EmailStr, str],
+        cls,
+        v: Union[EmailStr, str],
     ) -> EmailStr:
         """Validates that email is a valid email address
 
@@ -40,7 +42,6 @@ class Contact(BaseModel):
         if isinstance(v, str):
             v = EmailStr(v)
         return v
-
 
     class Config:
         extra = Extra.ignore

--- a/pydantic_openapi_schema/v3_1_0/contact.py
+++ b/pydantic_openapi_schema/v3_1_0/contact.py
@@ -1,6 +1,6 @@
-from typing import Optional
+from typing import Optional, Union
 
-from pydantic import AnyUrl, BaseModel, EmailStr, Extra
+from pydantic import AnyUrl, BaseModel, EmailStr, Extra, validator
 
 
 class Contact(BaseModel):
@@ -24,6 +24,24 @@ class Contact(BaseModel):
     The email address of the contact person/organization.
     MUST be in the form of an email address.
     """
+    @validator("email", pre=True)
+    def validate_email(  # pylint: disable=no-self-argument
+        cls, v: Union[EmailStr, str],
+    ) -> EmailStr:
+        """Validates that email is a valid email address
+
+        Args:
+            v (EmailStr|str): Holds the email string to be validated
+
+        Raises:
+            ValueError: Value is not a valid email address
+
+        Returns:
+            _type_: CompressionBackend
+        """
+        if isinstance(v, str):
+            v = EmailStr(v)
+        return v
 
     class Config:
         extra = Extra.ignore

--- a/pydantic_openapi_schema/v3_1_0/contact.py
+++ b/pydantic_openapi_schema/v3_1_0/contact.py
@@ -24,9 +24,11 @@ class Contact(BaseModel):
     The email address of the contact person/organization.
     MUST be in the form of an email address.
     """
+
     @validator("email", pre=True)
     def validate_email(  # pylint: disable=no-self-argument
-        cls, v: Union[EmailStr, str],
+        cls,
+        v: Union[EmailStr, str],
     ) -> EmailStr:
         """Validates that email is a valid email address
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ max-line-length = "120"
 ignored-argument-names = "args|kwargs|_|__"
 
 [tool.pylint.BASIC]
-good-names = "_,i,e,fn"
+good-names = "_,i,e,fn,v"
 
 [tool.coverage.run]
 omit = ["*/tests/*"]


### PR DESCRIPTION
This fix is to prevent IDEs such as VS Code from incorrectly reporting an error when setting `Contact.email` as a `str` instead of `EmailStr`.

```python

config = OpenAPIConfig(
    title="my-app",
    version=__version__,
    contact=Contact(
        name="Cody Fincher", email=EmailStr("codyfincher@google.com")
    ),
    description="Simple Single Page Application",
)

``` 
and 
```python

config = OpenAPIConfig(
    title="my-app",
    version=__version__,
    contact=Contact(
        name="Cody Fincher", email="codyfincher@google.com"
    ),
    description="Simple Single Page Application",
)

```
Both will now report as a valid instead of only the version with `EmailStr`