### PR TITLE
FIX: Apply type hint to 3.1 schema 

### DIFF
--- a/pydantic_openapi_schema/v3_1_0/contact.py
+++ b/pydantic_openapi_schema/v3_1_0/contact.py
@@ -19,7 +19,7 @@ class Contact(BaseModel):
     MUST be in the form of a URL.
     """
 
-    email: Optional[EmailStr] = None
+    email: Optional[Union[EmailStr, str]] = None
     """
     The email address of the contact person/organization.
     MUST be in the form of an email address.


### PR DESCRIPTION
The previous commit missed the type hint of `Union[EmailStr, str]` on the 3.1 OpenAPI schema.  This PR corrects that.