### PR TITLE
Change default value of explode attribute to None

### DIFF
--- a/pydantic_openapi_schema/v3_1_0/parameter.py
+++ b/pydantic_openapi_schema/v3_1_0/parameter.py
@@ -78,7 +78,7 @@ class Parameter(BaseModel):
     - for `cookie` - `form`.
     """
 
-    explode: bool = False
+    explode: Optional[bool] = None
     """When this is true, parameter values of type `array` or `object` generate
     separate parameters for each value of the array or key-value pair of the
     map.


### PR DESCRIPTION
Without this PR the `explode` attribute of `Parameter` is always `False` regardless of `in` and `style` attributes. But the correct behavior is different, and OpenAPI set default values by itself if attribute not provided.

Starlite doesn't support not exploded `Query` parameters (https://github.com/starlite-api/starlite/issues/1033).
For `Header`, `Cookie` parameters, as I can see, Starlite can't even work with arrays, because of parser.

I've tested this change with Starlite. Config test falls in [this place](https://github.com/starlite-api/starlite/blob/b21c0ef46a7cf5273218321f32b531428ea18fdf/tests/openapi/test_config.py#L15). Therefore, I will make appropriate PR to Starlite.

